### PR TITLE
adding tests and removing rstrip

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ For verbose output during the encryption or decryption process, add the `--debug
 python bkai-encrypt.py encrypt --input /path/to/your/input --key /path/to/your/cek.key --output /path/to/your/output --debug
 ```
 
+### Running Tests
+
+This utility is tested using Python's Unit Testing Framework with tests in [tests/test_encrypt.py](tests/test_encrypt.py). In order to execute the tests, you should install the cryptography dependency and run the following command:
+
+```bash
+python3 -m unittest tests/test_encrypt.py
+```
+
 ### After Encryption
 
 After encrypting your files, you can securely upload them to Azure Blob Storage for safekeeping. This script does not cover the upload process, but you can use Azure's CLI tools or SDKs in your preferred programming language to upload the encrypted files.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BeeKeeperAI Encryption Utility
 
-This utility, `bkai_encrypt.py` provides a secure method for encrypting and decrypting data steward files for use with the EscrowAI platform. It is designed to be run at the command line using both an input, output, and a pre-created Content Encrpytion Key (CEK).
+This utility, `bkai_encrypt.py` provides a secure method for encrypting and decrypting data set files for use with the EscrowAI platform. It is designed to be run at the command line using both an input, output, and a pre-created Content Encrpytion Key (CEK).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BeeKeeperAI Encryption Utility
 
-This utility, `bkai_encrypt.py` provides a secure method for encrypting and decrypting files for use with the EscrowAI platform. It is designed to be run at the command line using both an input, output, and a pre-created Content Encrpytion Key (CEK).
+This utility, `bkai_encrypt.py` provides a secure method for encrypting and decrypting data steward files for use with the EscrowAI platform. It is designed to be run at the command line using both an input, output, and a pre-created Content Encrpytion Key (CEK).
 
 ## Features
 
@@ -52,7 +52,7 @@ To decrypt, use the `decrypt` action with the paths to the encrypted folder or f
 
 
 ```bash
-python bkai_encrypt.py decrypt --input /path/to/your/encrypted/input --key /path/to/your/cek.key --output /path/to/your/output --zip optional_zip_name
+python3 bkai_encrypt.py decrypt --input /path/to/your/encrypted/input --key /path/to/your/cek.key --output /path/to/your/output --zip optional_zip_name
 ```
 
 ### Debug Mode
@@ -60,15 +60,7 @@ python bkai_encrypt.py decrypt --input /path/to/your/encrypted/input --key /path
 For verbose output during the encryption or decryption process, add the `--debug` flag:
 
 ```bash
-python bkai_encrypt.py encrypt --input /path/to/your/input --key /path/to/your/cek.key --output /path/to/your/output --debug
-```
-
-### Running Tests
-
-This utility is tested using Python's Unit Testing Framework with tests in [tests/test_encrypt.py](tests/test_encrypt.py). In order to execute the tests, you should install the cryptography dependency and run the following command:
-
-```bash
-python3 -m unittest tests/test_encrypt.py
+python3 bkai_encrypt.py encrypt --input /path/to/your/input --key /path/to/your/cek.key --output /path/to/your/output --debug
 ```
 
 ### After Encryption

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BeeKeeperAI Encryption Utility
 
-This utility, `bkai-encrypt.py` provides a secure method for encrypting and decrypting files for use with the EscrowAI platform. It is designed to be run at the command line using both an input, output, and a pre-created Content Encrpytion Key (CEK).
+This utility, `bkai_encrypt.py` provides a secure method for encrypting and decrypting files for use with the EscrowAI platform. It is designed to be run at the command line using both an input, output, and a pre-created Content Encrpytion Key (CEK).
 
 ## Features
 
@@ -43,7 +43,7 @@ To encrypt, specify the `encrypt` action, the paths for the input folder or file
 
 
 ```bash
-python3 bkai-encrypt.py encrypt --input /path/to/your/input --key /path/to/your/cek.key --output /path/to/your/output --zip optional_zip_name
+python3 bkai_encrypt.py encrypt --input /path/to/your/input --key /path/to/your/cek.key --output /path/to/your/output --zip optional_zip_name
 ```
 
 ### Decrypting a Folder or File
@@ -52,7 +52,7 @@ To decrypt, use the `decrypt` action with the paths to the encrypted folder or f
 
 
 ```bash
-python bkai-encrypt.py decrypt --input /path/to/your/encrypted/input --key /path/to/your/cek.key --output /path/to/your/output --zip optional_zip_name
+python bkai_encrypt.py decrypt --input /path/to/your/encrypted/input --key /path/to/your/cek.key --output /path/to/your/output --zip optional_zip_name
 ```
 
 ### Debug Mode
@@ -60,7 +60,7 @@ python bkai-encrypt.py decrypt --input /path/to/your/encrypted/input --key /path
 For verbose output during the encryption or decryption process, add the `--debug` flag:
 
 ```bash
-python bkai-encrypt.py encrypt --input /path/to/your/input --key /path/to/your/cek.key --output /path/to/your/output --debug
+python bkai_encrypt.py encrypt --input /path/to/your/input --key /path/to/your/cek.key --output /path/to/your/output --debug
 ```
 
 ### Running Tests

--- a/bkai_encrypt.py
+++ b/bkai_encrypt.py
@@ -47,8 +47,7 @@ def zip_content(input_path, zip_file_name):
 def encrypt_file(input_file_path, key_path, output_file_path):
     """Encrypt a file using AES-256-GCM with PBKDF2 key derivation."""
     with open(key_path, 'rb') as key_file:
-        password = key_file.read().rstrip()
-    password = password if isinstance(password, (bytes, bytearray)) else password.encode()
+        password = key_file.read()
 
     # Generate a random salt
     salt = os.urandom(8)
@@ -89,8 +88,7 @@ def decrypt_file(input_file_path, key_path, output_file_path):
     ciphertext = encrypted_data[16:]  # The rest is the ciphertext
     
     with open(key_path, 'rb') as key_file:
-        password = key_file.read().rstrip()
-    password = password if isinstance(password, (bytes, bytearray)) else password.encode()
+        password = key_file.read()
 
     # Derive key from password and salt using PBKDF2
     kdf = PBKDF2HMAC(
@@ -133,10 +131,9 @@ def decrypt_folder(input_folder_path, key_path, output_folder_path):
     for file_path in input_folder_path.rglob('*'):
         if file_path.is_file() and file_path.suffix == '.bkenc':
             rel_path = file_path.relative_to(input_folder_path)
-            # Remove the custom '.bkenc' extension
-            orig_extension = rel_path.suffixes[-2] if len(rel_path.suffixes) > 1 else ''
-            new_rel_path = rel_path.with_suffix(orig_extension)
-            dest_file_path = output_folder_path / new_rel_path
+            # Correctly handle the removal of '.bkenc' and restoration of the original file name
+            original_file_name = str(rel_path).replace('.bkenc', '')  # Directly remove '.bkenc'
+            dest_file_path = output_folder_path / original_file_name
             dest_file_path.parent.mkdir(parents=True, exist_ok=True)
             decrypt_file(str(file_path), key_path, str(dest_file_path))
 

--- a/tests/test_encrypt.py
+++ b/tests/test_encrypt.py
@@ -1,0 +1,98 @@
+import unittest
+import os
+from pathlib import Path
+import tempfile
+
+# Give our test script a chance to access bkai_encrypt in the parent folder.
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from bkai_encrypt import encrypt_file, decrypt_file, encrypt_folder, decrypt_folder
+
+class TestEncryptionUtils(unittest.TestCase):
+    def setUp(self):
+        # Temporary directory for testing
+        self.test_dir = tempfile.TemporaryDirectory()
+        self.test_file_path = Path(self.test_dir.name) / "test.txt"
+        self.encrypted_file_path = Path(self.test_dir.name) / "test.encrypted"
+        self.decrypted_file_path = Path(self.test_dir.name) / "test.decrypted"
+        self.key_path = Path(self.test_dir.name) / "CEK"
+
+        # Write a test file and a key
+        with open(self.test_file_path, 'w') as f:
+            f.write("This is a test.")
+        with open(self.key_path, 'wb') as f:
+            f.write(os.urandom(32))  # Simple key for testing; adjust as needed
+
+    def tearDown(self):
+        self.test_dir.cleanup()
+
+    def test_encrypt_decrypt_file(self):
+        # Test encryption
+        encrypt_file(self.test_file_path, self.key_path, self.encrypted_file_path)
+        self.assertTrue(self.encrypted_file_path.exists())
+
+        # Test decryption
+        decrypt_file(self.encrypted_file_path, self.key_path, self.decrypted_file_path)
+        self.assertTrue(self.decrypted_file_path.exists())
+
+        # Verify the decrypted content matches the original content
+        with open(self.test_file_path, 'r') as original, open(self.decrypted_file_path, 'r') as decrypted:
+            self.assertEqual(original.read(), decrypted.read())
+
+    def test_encrypt_decrypt_folder(self):
+        # Create a test folder structure
+        test_folder = Path(self.test_dir.name) / "test_folder"
+        test_folder.mkdir()
+        (test_folder / "subfolder").mkdir()
+        with open(test_folder / "file1.txt", 'w') as f:
+            f.write("File 1 content")
+        with open(test_folder / "subfolder/file2.txt", 'w') as f:
+            f.write("File 2 content")
+
+        encrypted_folder = Path(self.test_dir.name) / "encrypted_folder"
+        decrypted_folder = Path(self.test_dir.name) / "decrypted_folder"
+
+        # Validate the folders were created
+        self.assertTrue(test_folder.exists())
+        encrypted_folder.mkdir(parents=True, exist_ok=True) # Ensure the folder exists
+        self.assertTrue(encrypted_folder.exists())
+        decrypted_folder.mkdir(parents=True, exist_ok=True) # Ensure the folder exists
+        self.assertTrue(decrypted_folder.exists())
+
+        # Test folder encryption
+        encrypt_folder(test_folder, self.key_path, encrypted_folder)
+        self.assertTrue(any(encrypted_folder.rglob('*')), "Encryption folder is empty")
+
+        # Test folder decryption
+        decrypt_folder(encrypted_folder, self.key_path, decrypted_folder)
+        # List the files in the decrypted_folder
+        self.assertTrue(any(decrypted_folder.rglob('*')), "Decrypted folder is empty")
+
+        # Verify content of the decrypted files
+        with open(decrypted_folder / "file1.txt", 'r') as f:
+            self.assertEqual(f.read(), "File 1 content")
+        with open(decrypted_folder / "subfolder/file2.txt", 'r') as f:
+            self.assertEqual(f.read(), "File 2 content")
+
+    def test_encrypt_decrypt_with_rstrip_poisoned_bytes(self):
+        # Generate a key that ends with bytes that could be removed by rstrip
+        key_with_trimmable_bytes = os.urandom(30) + b'\x00\x20'
+        with open(self.key_path, 'wb') as f:
+            f.write(key_with_trimmable_bytes)
+
+        # Proceed with encryption and decryption using this special key
+        encrypt_file(self.test_file_path, self.key_path, self.encrypted_file_path)
+        self.assertTrue(self.encrypted_file_path.exists())
+
+        decrypt_file(self.encrypted_file_path, self.key_path, self.decrypted_file_path)
+        self.assertTrue(self.decrypted_file_path.exists())
+
+        # Verify the decrypted content matches the original content
+        with open(self.test_file_path, 'r') as original, open(self.decrypted_file_path, 'r') as decrypted:
+            self.assertEqual(original.read(), decrypted.read())
+
+# Run the tests
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This renames the the utility from bkai-encrypt.py to bkai_encrypt.py to support the addition of unittests to permanently capture the case of rstrip() mishandling of content encryption keys. This update also fixes this edge case with both the removal of rstrip and any attempt to encode a CEK that's read by default as bytes.